### PR TITLE
Support indexed expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ And what about if the `containerPort` property is at one place in the Deployment
 
 To ease up this use case, we can use wildcards. For example, using the expression "*.ports.containerPort", it would map all the container ports at any level.
 
+## Expressions with index
+
+For example, having the following YAML resource:
+
+```yaml
+apiVersion: v1
+kind: Resource
+metadata:
+  name: "a name"
+spec:
+  args:
+  - value 1
+  - value 2
+  - value 3
+```
+
+We can use this expression "spec.args[1]", to return the value at the position 1 which is "value 2".
+
 ## Escape characters
 
 If you want to select properties which key contains special characters like '.', you need to escape them using `'`, for example, using the path expression "".

--- a/src/main/java/io/github/yamlpath/WorkUnit.java
+++ b/src/main/java/io/github/yamlpath/WorkUnit.java
@@ -8,6 +8,7 @@ import static io.github.yamlpath.utils.PathUtils.PARENTHESIS_OPEN;
 import static io.github.yamlpath.utils.PathUtils.normalize;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 import io.github.yamlpath.utils.StringUtils;
 
@@ -16,6 +17,7 @@ public class WorkUnit {
     private Map<Object, Object> node;
     private Path lastVisited;
     private Object result;
+    private Consumer<String> replacementHook;
 
     public WorkUnit(Map<Object, Object> node, String expression) {
         this.node = node;
@@ -65,6 +67,10 @@ public class WorkUnit {
         return lastVisited;
     }
 
+    public void setReplacementHook(Consumer<String> replacementHook) {
+        this.replacementHook = replacementHook;
+    }
+
     public WorkUnit clone() {
         WorkUnit workUnit = new WorkUnit(this.node, this.expression);
         workUnit.lastVisited = this.lastVisited;
@@ -78,7 +84,11 @@ public class WorkUnit {
 
     protected void replaceResourceWith(String replacement) {
         if (lastVisited != null && !NO_REPLACEMENT.equals(replacement)) {
-            lastVisited.tree.put(lastVisited.part, replacement);
+            if (replacementHook != null) {
+                replacementHook.accept(replacement);
+            } else {
+                lastVisited.tree.put(lastVisited.part, replacement);
+            }
         }
     }
 

--- a/src/main/java/io/github/yamlpath/processor/IndexPartPathProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/IndexPartPathProcessor.java
@@ -1,0 +1,33 @@
+package io.github.yamlpath.processor;
+
+import static io.github.yamlpath.utils.PathUtils.INDEX_CLOSE;
+import static io.github.yamlpath.utils.PathUtils.INDEX_OPEN;
+
+import java.util.List;
+
+import io.github.yamlpath.WorkUnit;
+
+public class IndexPartPathProcessor implements PathProcessor {
+
+    @Override
+    public boolean canHandle(WorkUnit.Path path) {
+        return path.getPart().contains(INDEX_OPEN) && path.getPart().endsWith(INDEX_CLOSE);
+    }
+
+    @Override
+    public Object handle(WorkUnit workUnit, WorkUnit.Path path) {
+        int indexOfIndexOpen = path.getPart().indexOf(INDEX_OPEN);
+        String actualPart = path.getPart().substring(0, indexOfIndexOpen);
+
+        Object value = path.getTree().get(actualPart);
+        if (value instanceof List) {
+            int indexOfIndexClose = path.getPart().indexOf(INDEX_CLOSE);
+            int position = Integer.parseInt(path.getPart().substring(indexOfIndexOpen + 1, indexOfIndexClose));
+            workUnit.setReplacementHook(replacement -> ((List) value).set(position, replacement));
+
+            return ((List) value).get(position);
+        } else {
+            throw new IllegalStateException("Expected a collection at " + path.getPart());
+        }
+    }
+}

--- a/src/main/java/io/github/yamlpath/utils/PathUtils.java
+++ b/src/main/java/io/github/yamlpath/utils/PathUtils.java
@@ -8,6 +8,8 @@ public final class PathUtils {
     public static final String DOT = ".";
     public static final String PARENTHESIS_OPEN = "(";
     public static final String PARENTHESIS_CLOSE = ")";
+    public static final String INDEX_OPEN = "[";
+    public static final String INDEX_CLOSE = "]";
 
     private PathUtils() {
 

--- a/src/main/resources/META-INF/services/io.github.yamlpath.processor.PathProcessor
+++ b/src/main/resources/META-INF/services/io.github.yamlpath.processor.PathProcessor
@@ -1,3 +1,4 @@
 io.github.yamlpath.processor.PartPathProcessor
 io.github.yamlpath.processor.WildcardPartPathProcessor
 io.github.yamlpath.processor.ExpressionPathProcessor
+io.github.yamlpath.processor.IndexPartPathProcessor

--- a/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
+++ b/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
@@ -120,6 +120,13 @@ public class YamlExpressionParserTest {
         assertGeneratedYaml("parseExpressionWithCommandArray");
     }
 
+    @Test
+    public void parseExpressionWithCommandAndPosition() throws IOException {
+        String found = parser.readSingleAndReplace("*.containers.command[1]", "{{ .Values.app.the-command }}");
+        assertEquals("command2", found);
+        assertGeneratedYaml("parseExpressionWithCommandAndPosition");
+    }
+
     private void assertGeneratedYaml(String method) throws IOException {
         String actual = parser.dumpAsString();
         String expected = StringUtils

--- a/src/test/resources/expected-parseExpressionWithCommandAndPosition-kubernetes.yml
+++ b/src/test/resources/expected-parseExpressionWithCommandAndPosition-kubernetes.yml
@@ -1,0 +1,38 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: example
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              command:
+                - command1
+                - "{{ .Values.app.the-command }}"


### PR DESCRIPTION
For example, having the following YAML resource:
```yaml
apiVersion: v1
kind: Resource
metadata:
  name: "a name"
spec:
  args:
  - 1
  - 2
  - 3
```

Using the expression "spec.args", it would return a list of 1, 2, 3.

But we can't get a concrete position of these values. 

With these changes, we support expressions index-based like "spec.args[1]" that we would return "2".

Fix https://github.com/yaml-path/YamlPath/issues/43