### PR TITLE
Improve the support of filters to support any number, not equal and other comparison operators for numbers

### DIFF
--- a/src/main/java/io/github/yamlpath/processor/ExpressionPathProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/ExpressionPathProcessor.java
@@ -24,7 +24,8 @@ public class ExpressionPathProcessor implements PathProcessor {
         this.supportedExpressions = StreamSupport
                 .stream(ServiceLoader.load(ExpressionProcessor.class, ExpressionPathProcessor.class.getClassLoader())
                         .spliterator(), false)
-                .sorted(Comparator.comparingInt(ExpressionProcessor::getPriority)).collect(Collectors.toList());
+                .sorted(Comparator.comparingInt(ExpressionProcessor::getPriority).reversed())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/io/github/yamlpath/processor/expressions/GreaterOrEqualThanExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/GreaterOrEqualThanExpressionProcessor.java
@@ -1,0 +1,23 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class GreaterOrEqualThanExpressionProcessor extends NumberExpressionProcessor {
+
+    @Override
+    public String operator() {
+        return ">=";
+    }
+
+    @Override
+    public int getPriority() {
+        // to give it more priority than the GreaterThanExpressionProcessor processor.
+        return 1;
+    }
+
+    @Override
+    boolean evaluate(BigDecimal left, BigDecimal right, Map<Object, Object> node) {
+        return left.compareTo(right) >= 0;
+    }
+}

--- a/src/main/java/io/github/yamlpath/processor/expressions/GreaterThanExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/GreaterThanExpressionProcessor.java
@@ -1,0 +1,17 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class GreaterThanExpressionProcessor extends NumberExpressionProcessor {
+
+    @Override
+    public String operator() {
+        return ">";
+    }
+
+    @Override
+    boolean evaluate(BigDecimal left, BigDecimal right, Map<Object, Object> node) {
+        return left.compareTo(right) > 0;
+    }
+}

--- a/src/main/java/io/github/yamlpath/processor/expressions/IsEqualExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/IsEqualExpressionProcessor.java
@@ -21,6 +21,8 @@ public class IsEqualExpressionProcessor implements ExpressionProcessor {
         Object value = parser.readSingle(left);
         if (value instanceof Integer) {
             return Integer.valueOf(right).equals(value);
+        } else if (value instanceof Boolean) {
+            return Boolean.valueOf(right).equals(value);
         }
 
         return StringUtils.equals(value, right);

--- a/src/main/java/io/github/yamlpath/processor/expressions/IsEqualExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/IsEqualExpressionProcessor.java
@@ -8,19 +8,17 @@ import io.github.yamlpath.utils.StringUtils;
 
 public class IsEqualExpressionProcessor implements ExpressionProcessor {
 
-    private static final String IS_EQUAL = "==";
-
     @Override
     public String operator() {
-        return IS_EQUAL;
+        return "==";
     }
 
     @Override
     public boolean evaluate(String left, String right, Map<Object, Object> resource) {
         YamlExpressionParser parser = new YamlExpressionParser(Collections.singletonList(resource));
         Object value = parser.readSingle(left);
-        if (value instanceof Integer) {
-            return Integer.valueOf(right).equals(value);
+        if (value instanceof Number) {
+            return String.valueOf(value).equals(right);
         } else if (value instanceof Boolean) {
             return Boolean.valueOf(right).equals(value);
         }

--- a/src/main/java/io/github/yamlpath/processor/expressions/IsNotEqualExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/IsNotEqualExpressionProcessor.java
@@ -1,0 +1,16 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.util.Map;
+
+public class IsNotEqualExpressionProcessor extends IsEqualExpressionProcessor {
+
+    @Override
+    public String operator() {
+        return "!=";
+    }
+
+    @Override
+    public boolean evaluate(String left, String right, Map<Object, Object> resource) {
+        return !super.evaluate(left, right, resource);
+    }
+}

--- a/src/main/java/io/github/yamlpath/processor/expressions/LesserOrEqualThanExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/LesserOrEqualThanExpressionProcessor.java
@@ -1,0 +1,23 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class LesserOrEqualThanExpressionProcessor extends NumberExpressionProcessor {
+
+    @Override
+    public String operator() {
+        return "<=";
+    }
+
+    @Override
+    public int getPriority() {
+        // to give it more priority than the LesserThanExpressionProcessor processor.
+        return 1;
+    }
+
+    @Override
+    boolean evaluate(BigDecimal left, BigDecimal right, Map<Object, Object> node) {
+        return left.compareTo(right) <= 0;
+    }
+}

--- a/src/main/java/io/github/yamlpath/processor/expressions/LesserThanExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/LesserThanExpressionProcessor.java
@@ -1,0 +1,17 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class LesserThanExpressionProcessor extends NumberExpressionProcessor {
+
+    @Override
+    public String operator() {
+        return "<";
+    }
+
+    @Override
+    boolean evaluate(BigDecimal left, BigDecimal right, Map<Object, Object> node) {
+        return left.compareTo(right) < 0;
+    }
+}

--- a/src/main/java/io/github/yamlpath/processor/expressions/NumberExpressionProcessor.java
+++ b/src/main/java/io/github/yamlpath/processor/expressions/NumberExpressionProcessor.java
@@ -1,0 +1,22 @@
+package io.github.yamlpath.processor.expressions;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
+
+import io.github.yamlpath.YamlExpressionParser;
+
+public abstract class NumberExpressionProcessor implements ExpressionProcessor {
+
+    abstract boolean evaluate(BigDecimal left, BigDecimal right, Map<Object, Object> node);
+
+    public final boolean evaluate(String left, String right, Map<Object, Object> node) {
+        YamlExpressionParser parser = new YamlExpressionParser(Collections.singletonList(node));
+        Object value = parser.readSingle(left);
+        if (value instanceof Number) {
+            return evaluate(new BigDecimal(value.toString()), new BigDecimal(right), node);
+        }
+
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/services/io.github.yamlpath.processor.expressions.ExpressionProcessor
+++ b/src/main/resources/META-INF/services/io.github.yamlpath.processor.expressions.ExpressionProcessor
@@ -1,4 +1,5 @@
 io.github.yamlpath.processor.expressions.IsEqualExpressionProcessor
+io.github.yamlpath.processor.expressions.IsNotEqualExpressionProcessor
 io.github.yamlpath.processor.expressions.GreaterThanExpressionProcessor
 io.github.yamlpath.processor.expressions.GreaterOrEqualThanExpressionProcessor
 io.github.yamlpath.processor.expressions.LesserThanExpressionProcessor

--- a/src/main/resources/META-INF/services/io.github.yamlpath.processor.expressions.ExpressionProcessor
+++ b/src/main/resources/META-INF/services/io.github.yamlpath.processor.expressions.ExpressionProcessor
@@ -1,1 +1,5 @@
 io.github.yamlpath.processor.expressions.IsEqualExpressionProcessor
+io.github.yamlpath.processor.expressions.GreaterThanExpressionProcessor
+io.github.yamlpath.processor.expressions.GreaterOrEqualThanExpressionProcessor
+io.github.yamlpath.processor.expressions.LesserThanExpressionProcessor
+io.github.yamlpath.processor.expressions.LesserOrEqualThanExpressionProcessor

--- a/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
+++ b/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
@@ -48,6 +48,41 @@ public class YamlExpressionParserTest {
     }
 
     @Test
+    public void parseExpressionUsingFilterOfTypeNumber() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble == 2.2).route");
+        assertEquals("example.com", found);
+    }
+
+    @Test
+    public void parseExpressionUsingGreaterFilter() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble > 3).route");
+        assertEquals("www.example.com/foo", found);
+    }
+
+    @Test
+    public void parseExpressionUsingGreaterOrEqualFilter() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble >= 3.5).route");
+        assertEquals("www.example.com/foo", found);
+    }
+
+    @Test
+    public void parseExpressionUsingLesserFilter() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble < 3).route");
+        assertEquals("example.com", found);
+    }
+
+    @Test
+    public void parseExpressionUsingLesserThanFilter() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble <= 2.2).route");
+        assertEquals("example.com", found);
+    }
+
+    @Test
     public void parseExpressionWithEscape() throws IOException {
         String found = parser.readSingleAndReplace("spec.selector.matchLabels.'app.kubernetes.io/name'",
                 "{{ .Values.app.label }}");

--- a/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
+++ b/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
@@ -55,6 +55,13 @@ public class YamlExpressionParserTest {
     }
 
     @Test
+    public void parseExpressionUsingNotEqualFilter() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble != 2.2).route");
+        assertEquals("www.example.com/foo", found);
+    }
+
+    @Test
     public void parseExpressionUsingGreaterFilter() throws IOException {
         parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
         String found = parser.readSingle("applications.(name == my-app).routes.(filterDouble > 3).route");

--- a/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
+++ b/src/test/java/io/github/yamlpath/YamlExpressionParserTest.java
@@ -41,6 +41,13 @@ public class YamlExpressionParserTest {
     }
 
     @Test
+    public void parseExpressionUsingFilterOfTypeBoolean() throws IOException {
+        parser = YamlPath.from(YamlExpressionParserTest.class.getResourceAsStream("/test-routes.yml"));
+        String found = parser.readSingle("applications.(name == my-app).routes.(filterBoolean == true).route");
+        assertEquals("example.com", found);
+    }
+
+    @Test
     public void parseExpressionWithEscape() throws IOException {
         String found = parser.readSingleAndReplace("spec.selector.matchLabels.'app.kubernetes.io/name'",
                 "{{ .Values.app.label }}");

--- a/src/test/resources/test-routes.yml
+++ b/src/test/resources/test-routes.yml
@@ -1,0 +1,12 @@
+---
+applications:
+  name: my-app
+  routes:
+    - route: example.com
+      filterBoolean: true
+    - route: www.example.com/foo
+      filterBoolean: false
+  env:
+    greeting: hello
+    BUNDLE_WITHOUT: test:development
+    stuff: other

--- a/src/test/resources/test-routes.yml
+++ b/src/test/resources/test-routes.yml
@@ -4,8 +4,10 @@ applications:
   routes:
     - route: example.com
       filterBoolean: true
+      filterDouble: 2.2
     - route: www.example.com/foo
       filterBoolean: false
+      filterDouble: 3.5
   env:
     greeting: hello
     BUNDLE_WITHOUT: test:development


### PR DESCRIPTION
Having the following YAML file:
```yaml
component:
  - name: foo
    releases:
      - version: 12.0.0
        redirectOnly: false
      - version: 12.1.0
        redirectOnly: true
      - version: 12.1.1
        redirectOnly: true
  - name: bar
    releases:
      - version: 0.6.0
platform:
  - name: baz
    releases:
      - version: HEAD
        redirectOnly: false
```

When using the expression `component.(name == foo).releases.(redirectOnly == false).version`, you got no results because the `redirectOnly` is a boolean.
This PR adds support of filtering by booleans, so using the above expresion, you would get the version `12.0.0`. 

Additionally, we are also adding support for any kind of numbers for equal operator `==`. Plus, adding the not equal `!=`, the greater than (`>`), greater or equal than `>=`, lesser than `<` and lesser or equal than `<=` operators.


Fix https://github.com/yaml-path/YamlPath/issues/171